### PR TITLE
Preserve elements classes

### DIFF
--- a/dist/morphist.css
+++ b/dist/morphist.css
@@ -1,7 +1,3 @@
-.morphist > * {
+.morphist > *:not(.animated) {
     display: none;
-}
-
-.morphist > .animated {
-    display: inline-block;
 }

--- a/dist/morphist.js
+++ b/dist/morphist.js
@@ -60,7 +60,7 @@
             $elem.one("webkitAnimationEnd mozAnimationEnd MSAnimationEnd" +
                         "oanimationend animationend", function () {
                 if ($elem.hasClass("mis-out")) {
-                    $elem.removeClass();
+                    $elem.removeClass("animated mis-out " + $that.settings.animateOut);
                     $that.index = ++$that.index % $that.children.length;
                     $that.loop();
                 }
@@ -75,7 +75,7 @@
         },
         _animateOut: function () {
             var element = this.children.eq(this.index);
-            element.removeClass();
+            element.removeClass("animated mis-in " + this.settings.animateIn);
             if (this.settings.animateIn === this.settings.animateOut) {
                 /*eslint-disable */
                 element[0].offsetWidth;

--- a/index.html
+++ b/index.html
@@ -13,10 +13,10 @@
         <div style="text-align:center">
             I am a...
             <ul id="js-rotating">
-                <li>So Simple</li>
-                <li>Very Doge</li>
-                <li>Much Wow</li>
-                <li>Such Cool</li>
+                <li class="c1">So Simple</li>
+                <li class="c2">Very Doge</li>
+                <li class="c3">Much Wow</li>
+                <li class="c4">Such Cool</li>
             </ul>
             ...child object rotator.
         </div>


### PR DESCRIPTION
if animated elements have class, this PR allows to preserve them but removing just the classes added by morphist.

P.S. Github somehow lost sync with the previous PR, my fault probably since I should have used a branch instead of merging in my master, so it push again the css change, sorry about that, but I think reverting it might just pollute the graphs a little more
